### PR TITLE
SDK version constraint changed (from >=2.3.0 to >=2.2.0)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: dart
 dart:
-- "2.3.0"
+- "2.2.0"
 dart_task:
 - test: --platform vm
 - dartanalyzer: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 10.0.4
+- `pubspec.yaml`: sdk version constraint changed from `>=2.3.0` to `>=2.2.0` 
+
 ## 10.0.3
 - `Float32Matrix.columns`: empty list supported as a source
 - `Float32Matrix.rows`: empty list supported as a source

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.1"
+    version: "1.5.2"
   async:
     dependency: transitive
     description:
@@ -56,21 +56,21 @@ packages:
       name: build_daemon
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.1"
+    version: "1.0.0"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.0"
+    version: "1.5.0"
   build_runner_core:
     dependency: transitive
     description:
@@ -91,14 +91,14 @@ packages:
       name: built_collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.2.1"
+    version: "4.2.2"
   built_value:
     dependency: transitive
     description:
       name: built_value
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.5.0"
+    version: "6.6.0"
   charcode:
     dependency: transitive
     description:
@@ -161,7 +161,7 @@ packages:
       name: file
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.7"
+    version: "5.0.8"
   fixnum:
     dependency: transitive
     description:
@@ -245,7 +245,7 @@ packages:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.0"
+    version: "2.4.0"
   json_rpc_2:
     dependency: transitive
     description:
@@ -294,7 +294,7 @@ packages:
       name: mime
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.6+2"
+    version: "0.9.6+3"
   mockito:
     dependency: "direct dev"
     description:
@@ -539,7 +539,7 @@ packages:
       name: web_socket_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.12"
+    version: "1.0.13"
   xrange:
     dependency: "direct main"
     description:
@@ -555,4 +555,4 @@ packages:
     source: hosted
     version: "2.1.15"
 sdks:
-  dart: ">=2.3.0 <3.0.0"
+  dart: ">=2.3.0-dev.0.1 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: ml_linalg
 description: SIMD-based linear algebra (1 operation on 4 float32 values, 1 operation on 2 float64 values)
-version: 10.0.3
+version: 10.0.4
 author: Ilia Gyrdymov <ilgyrd@gmail.com>
 homepage: https://github.com/gyrdym/ml_linalg
 
 environment:
-  sdk: '>=2.3.0 <3.0.0'
+  sdk: '>=2.2.0 <3.0.0'
 
 dependencies:
   quiver: '>=2.0.0 <3.0.0'


### PR DESCRIPTION
There is no usage of any functionality from Dart SDK 2.3.0 at all in the project, so there is no need to have a minimum version as 2.3.0 in pubspec