### PR TITLE
Add Float32VectorSparse with fromMap constructor

### DIFF
--- a/lib/src/common/hash/finalize_hash.dart
+++ b/lib/src/common/hash/finalize_hash.dart
@@ -1,0 +1,6 @@
+/// Applies a final avalanche step to improve bit distribution of [hash].
+int finalizeHash(int hash) {
+  hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
+  hash ^= hash >> 11;
+  return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
+}

--- a/lib/src/common/hash/mix_hash.dart
+++ b/lib/src/common/hash/mix_hash.dart
@@ -1,0 +1,6 @@
+/// Mixes [value] into [hash] so nearby inputs diverge across many bits.
+int mixHash(int hash, int value) {
+  hash = 0x1fffffff & (hash + value);
+  hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
+  return hash ^ (hash >> 6);
+}

--- a/lib/src/vector/float32_vector_sparse.dart
+++ b/lib/src/vector/float32_vector_sparse.dart
@@ -1,0 +1,719 @@
+import 'dart:collection';
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:ml_linalg/distance.dart';
+import 'package:ml_linalg/dtype.dart';
+import 'package:ml_linalg/matrix.dart';
+import 'package:ml_linalg/norm.dart';
+import 'package:ml_linalg/src/common/cache_manager/cache_manager.dart';
+import 'package:ml_linalg/src/common/cache_manager/cache_manager_factory_impl.dart';
+import 'package:ml_linalg/src/common/exception/unsupported_operand_type_exception.dart';
+import 'package:ml_linalg/src/vector/exception/cosine_of_zero_vector_exception.dart';
+import 'package:ml_linalg/src/vector/exception/empty_vector_exception.dart';
+import 'package:ml_linalg/src/vector/exception/unsupported_distance_type_exception.dart';
+import 'package:ml_linalg/src/vector/exception/unsupported_norm_type_exception.dart';
+import 'package:ml_linalg/src/vector/exception/vector_list_length_mismatch_exception.dart';
+import 'package:ml_linalg/src/vector/exception/vectors_length_mismatch_exception.dart';
+import 'package:ml_linalg/src/vector/serialization/vector_to_json.dart';
+import 'package:ml_linalg/src/vector/vector_cache_keys.dart';
+import 'package:ml_linalg/vector.dart';
+
+/// A float32 sparse vector that stores only non-zero values.
+///
+/// Missing indices are treated as `0.0`.
+class Float32VectorSparse with IterableMixin<double> implements Vector {
+  /// Creates a sparse vector from [source], where keys are indices and values
+  /// are vector elements.
+  ///
+  /// Zero values in [source] are ignored. Indices must be in `[0, length)`.
+  Float32VectorSparse.fromMap(
+    Map<int, num> source, {
+    required this.length,
+  }) : _cache = const CacheManagerFactoryImpl().create(vectorCacheKeys) {
+    if (length < 0) {
+      throw ArgumentError.value(length, 'length', 'Cannot be negative');
+    }
+
+    final entries = <MapEntry<int, double>>[];
+
+    source.forEach((index, value) {
+      if (index < 0 || index >= length) {
+        throw RangeError.range(index, 0, length - 1, 'index');
+      }
+
+      final doubleValue = value.toDouble();
+
+      if (doubleValue != 0.0) {
+        entries.add(MapEntry(index, doubleValue));
+      }
+    });
+
+    entries.sort((a, b) => a.key.compareTo(b.key));
+
+    _indices = Int32List(entries.length);
+    _values = Float32List(entries.length);
+
+    for (var i = 0; i < entries.length; i++) {
+      _indices[i] = entries[i].key;
+      _values[i] = entries[i].value;
+    }
+  }
+
+  Float32VectorSparse._raw({
+    required this.length,
+    required Int32List indices,
+    required Float32List values,
+    required CacheManager cache,
+  })  : _indices = indices,
+        _values = values,
+        _cache = cache;
+
+  @override
+  final int length;
+
+  final CacheManager _cache;
+
+  late final Int32List _indices;
+  late final Float32List _values;
+
+  int get nnz => _indices.length;
+
+  @override
+  DType get dtype => DType.float32;
+
+  @override
+  Iterator<double> get iterator =>
+      _Float32VectorSparseIterator(_indices, _values, length);
+
+  @override
+  double operator [](int index) {
+    if (isEmpty) {
+      throw EmptyVectorException();
+    }
+
+    if (index < 0 || index >= length) {
+      throw RangeError.index(index, this);
+    }
+
+    final position = _indexOf(index);
+
+    return position < 0 ? 0.0 : _values[position];
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+
+    if (other is! Float32VectorSparse) {
+      return false;
+    }
+
+    if (length != other.length || nnz != other.nnz) {
+      return false;
+    }
+
+    for (var i = 0; i < nnz; i++) {
+      if (_indices[i] != other._indices[i] || _values[i] != other._values[i]) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  @override
+  int get hashCode => _cache.get(vectorHashKey, () {
+        if (isEmpty) {
+          return 0;
+        }
+
+        var hash = length;
+
+        for (var i = 0; i < nnz; i++) {
+          hash = 31 * hash + _indices[i];
+          hash = 31 * hash + _values[i].hashCode;
+        }
+
+        return hash;
+      }, skipCaching: false);
+
+  @override
+  Vector operator +(Object value) => _asDense() + value;
+
+  @override
+  Vector operator -(Object value) => _asDense() - value;
+
+  @override
+  Vector operator *(Object value) {
+    if (value is num) {
+      return _mapValues((element) => element * value.toDouble());
+    }
+
+    if (value is Float32VectorSparse) {
+      if (value.length != length) {
+        throw VectorsLengthMismatchException(length, value.length);
+      }
+
+      return _multiplySparse(value);
+    }
+
+    if (value is Vector) {
+      if (value.length != length) {
+        throw VectorsLengthMismatchException(length, value.length);
+      }
+
+      return _mapEntries((index, element) => element * value[index]);
+    }
+
+    if (value is Iterable<num>) {
+      if (value.length != length) {
+        throw VectorListLengthMismatchException(length, value.length);
+      }
+
+      if (value is List<num>) {
+        return _mapEntries((index, element) => element * value[index]);
+      }
+
+      return _asDense() * value;
+    }
+
+    if (value is Matrix) {
+      return _asDense() * value;
+    }
+
+    throw UnsupportedOperandTypeException(value.runtimeType,
+        operationName: 'Vector "*" operator');
+  }
+
+  @override
+  Vector operator /(Object value) {
+    if (value is num) {
+      return _mapValues((element) => element / value.toDouble());
+    }
+
+    return _asDense() / value;
+  }
+
+  @override
+  Vector sqrt({bool skipCaching = false}) =>
+      _cache.get(vectorSqrtKey, () => _asDense().sqrt(skipCaching: true),
+          skipCaching: skipCaching);
+
+  @override
+  Vector scalarDiv(num scalar) => this / scalar;
+
+  @override
+  Vector pow(num exponent) {
+    if (exponent == 0) {
+      return Vector.filled(length, 1.0, dtype: dtype);
+    }
+
+    // Negative exponents turn implicit zeros into infinities, so densify.
+    if (exponent < 0) {
+      return _asDense().pow(exponent);
+    }
+
+    return _mapValues((value) => math.pow(value, exponent).toDouble());
+  }
+
+  @override
+  Vector exp({bool skipCaching = false}) =>
+      _cache.get(vectorExpKey, () => _asDense().exp(skipCaching: true),
+          skipCaching: skipCaching);
+
+  @override
+  Vector log({bool skipCaching = false}) =>
+      _cache.get(vectorLogKey, () => _asDense().log(skipCaching: true),
+          skipCaching: skipCaching);
+
+  @override
+  Vector abs({bool skipCaching = false}) => _cache.get(
+        vectorAbsKey,
+        () => _mapValues((value) => value.abs()),
+        skipCaching: skipCaching,
+      );
+
+  @override
+  double dot(Vector vector) {
+    if (vector.length != length) {
+      throw VectorsLengthMismatchException(length, vector.length);
+    }
+
+    var result = 0.0;
+
+    for (var i = 0; i < nnz; i++) {
+      result += _values[i] * vector[_indices[i]];
+    }
+
+    return result;
+  }
+
+  @override
+  double distanceTo(
+    Vector other, {
+    Distance distance = Distance.euclidean,
+  }) {
+    switch (distance) {
+      case Distance.euclidean:
+        return (this - other).norm(Norm.euclidean);
+
+      case Distance.manhattan:
+        return (this - other).norm(Norm.manhattan);
+
+      case Distance.cosine:
+        return 1 - getCosine(other);
+
+      case Distance.hamming:
+        return _hammingDistance(other);
+
+      default:
+        throw UnsupportedDistanceTypeException(distance);
+    }
+  }
+
+  @override
+  double getCosine(Vector other) {
+    final cosine =
+        (dot(other) / norm(Norm.euclidean) / other.norm(Norm.euclidean));
+
+    if (cosine.isInfinite || cosine.isNaN) {
+      throw CosineOfZeroVectorException();
+    }
+
+    return cosine;
+  }
+
+  @override
+  double mean({bool skipCaching = false}) {
+    if (isEmpty) {
+      throw EmptyVectorException();
+    }
+
+    return _cache.get(
+        vectorMeanKey, () => sum(skipCaching: skipCaching) / length,
+        skipCaching: skipCaching);
+  }
+
+  @override
+  double median({bool skipCaching = false}) {
+    if (isEmpty) {
+      throw EmptyVectorException();
+    }
+
+    return _cache.get(vectorMedianKey, () {
+      if (length == 1) {
+        return this[0];
+      }
+
+      final sorted = _toFloat32List()..sort();
+      final isOdd = length % 2 != 0;
+      final midIndex = ((length - 1) / 2).floor();
+
+      return isOdd
+          ? sorted[midIndex]
+          : (sorted[midIndex] + sorted[midIndex + 1]) / 2;
+    }, skipCaching: skipCaching);
+  }
+
+  @override
+  double norm([Norm normType = Norm.euclidean, bool skipCaching = false]) =>
+      _cache.get(getCacheKeyForNormByNormType(normType), () {
+        final power = _powerByNormType(normType);
+
+        if (power == 1) {
+          return abs(skipCaching: true).sum(skipCaching: true);
+        }
+
+        var sumOfPowers = 0.0;
+
+        for (var i = 0; i < nnz; i++) {
+          sumOfPowers += math.pow(_values[i].abs(), power).toDouble();
+        }
+
+        return math.pow(sumOfPowers, 1 / power).toDouble();
+      }, skipCaching: skipCaching);
+
+  @override
+  double sum({bool skipCaching = false}) {
+    if (isEmpty) {
+      return double.nan;
+    }
+
+    return _cache.get(vectorSumKey, () {
+      var result = 0.0;
+
+      for (var i = 0; i < nnz; i++) {
+        result += _values[i];
+      }
+
+      return result;
+    }, skipCaching: skipCaching);
+  }
+
+  @override
+  double prod() {
+    if (isEmpty) {
+      return double.nan;
+    }
+
+    if (nnz < length) {
+      return 0.0;
+    }
+
+    var result = 1.0;
+
+    for (var i = 0; i < nnz; i++) {
+      result *= _values[i];
+    }
+
+    return result;
+  }
+
+  @override
+  double max({bool skipCaching = false}) => _cache.get(vectorMaxKey, () {
+        if (isEmpty) {
+          return _asDense().max(skipCaching: true);
+        }
+
+        if (nnz == 0) {
+          return 0.0;
+        }
+
+        var result = _values[0];
+
+        for (var i = 1; i < nnz; i++) {
+          result = math.max(result, _values[i]);
+        }
+
+        if (nnz < length) {
+          result = math.max(result, 0.0);
+        }
+
+        return result;
+      }, skipCaching: skipCaching);
+
+  @override
+  double min({bool skipCaching = false}) => _cache.get(vectorMinKey, () {
+        if (isEmpty) {
+          return _asDense().min(skipCaching: true);
+        }
+
+        if (nnz == 0) {
+          return 0.0;
+        }
+
+        var result = _values[0];
+
+        for (var i = 1; i < nnz; i++) {
+          result = math.min(result, _values[i]);
+        }
+
+        if (nnz < length) {
+          result = math.min(result, 0.0);
+        }
+
+        return result;
+      }, skipCaching: skipCaching);
+
+  @override
+  Vector sample(Iterable<int> indices) {
+    final list = Float32List(indices.length);
+    var i = 0;
+
+    for (final index in indices) {
+      list[i++] = this[index];
+    }
+
+    return Vector.fromList(list, dtype: dtype);
+  }
+
+  @override
+  Vector unique({bool skipCaching = false}) => _cache.get(
+        vectorUniqueKey,
+        () => Vector.fromList(
+          Set<double>.from(this).toList(growable: false),
+          dtype: dtype,
+        ),
+        skipCaching: skipCaching,
+      );
+
+  @override
+  Vector normalize(
+          [Norm normType = Norm.euclidean, bool skipCaching = false]) =>
+      _cache.get(
+        getCacheKeyForNormalizeByNormType(normType),
+        () => this / norm(normType, true),
+        skipCaching: skipCaching,
+      );
+
+  @override
+  Vector rescale({bool skipCaching = false}) =>
+      _cache.get(vectorRescaleKey, () {
+        final minValue = min(skipCaching: true);
+        final maxValue = max(skipCaching: true);
+
+        return (this - minValue) / (maxValue - minValue);
+      }, skipCaching: skipCaching);
+
+  @override
+  Vector set(int index, num value) {
+    if (index < 0 || index >= length) {
+      throw RangeError.index(index, this);
+    }
+
+    final map = <int, num>{
+      for (var i = 0; i < nnz; i++) _indices[i]: _values[i],
+    };
+
+    if (value == 0) {
+      map.remove(index);
+    } else {
+      map[index] = value;
+    }
+
+    return Float32VectorSparse.fromMap(map, length: length);
+  }
+
+  @override
+  Vector fastMap<T>(T Function(T element) mapper) =>
+      _asDense().fastMap(mapper);
+
+  @override
+  Vector mapToVector(double Function(double value) mapper) =>
+      Vector.fromList(_toFloat32List().map(mapper).toList(), dtype: dtype);
+
+  @override
+  Vector filterElements(bool Function(double element, int idx) predicate) {
+    final result = <double>[];
+
+    for (var i = 0; i < length; i++) {
+      final value = this[i];
+
+      if (predicate(value, i)) {
+        result.add(value);
+      }
+    }
+
+    return Vector.fromList(result, dtype: dtype);
+  }
+
+  @override
+  Vector subvector(int start, [int? end]) {
+    if (start < 0) {
+      throw RangeError.range(
+          start,
+          0,
+          length - 1,
+          '`start` cannot'
+          ' be negative, `start`: $start');
+    }
+
+    if (end != null && start >= end) {
+      throw RangeError.range(start, 0, length - 1,
+          '`start` cannot be greater than or equal to `end`, `start`: $start, `end`: $end');
+    }
+
+    if (start >= length) {
+      throw RangeError.range(
+          start,
+          0,
+          length - 1,
+          '`start` cannot be greater than or equal to the vector'
+          'length, `start`: $start');
+    }
+
+    final limit = end == null || end > length ? length : end;
+    final map = <int, num>{};
+
+    for (var i = 0; i < nnz; i++) {
+      final index = _indices[i];
+
+      if (index >= start && index < limit) {
+        map[index - start] = _values[i];
+      }
+    }
+
+    return Float32VectorSparse.fromMap(map, length: limit - start);
+  }
+
+  @override
+  Map<String, dynamic> toJson() => vectorToJson(this)!;
+
+  Vector _asDense() => Vector.fromList(_toFloat32List(), dtype: dtype);
+
+  Float32List _toFloat32List() {
+    final result = Float32List(length);
+
+    for (var i = 0; i < nnz; i++) {
+      result[_indices[i]] = _values[i];
+    }
+
+    return result;
+  }
+
+  Float32VectorSparse _mapValues(double Function(double value) mapper) {
+    final indices = Int32List(nnz);
+    final values = Float32List(nnz);
+    var count = 0;
+
+    for (var i = 0; i < nnz; i++) {
+      final mapped = mapper(_values[i]);
+
+      if (mapped != 0.0) {
+        indices[count] = _indices[i];
+        values[count] = mapped;
+        count++;
+      }
+    }
+
+    return Float32VectorSparse._raw(
+      length: length,
+      indices: Int32List.sublistView(indices, 0, count),
+      values: Float32List.sublistView(values, 0, count),
+      cache: const CacheManagerFactoryImpl().create(vectorCacheKeys),
+    );
+  }
+
+  Float32VectorSparse _mapEntries(
+      double Function(int index, double value) mapper) {
+    final indices = Int32List(nnz);
+    final values = Float32List(nnz);
+    var count = 0;
+
+    for (var i = 0; i < nnz; i++) {
+      final mapped = mapper(_indices[i], _values[i]);
+
+      if (mapped != 0.0) {
+        indices[count] = _indices[i];
+        values[count] = mapped;
+        count++;
+      }
+    }
+
+    return Float32VectorSparse._raw(
+      length: length,
+      indices: Int32List.sublistView(indices, 0, count),
+      values: Float32List.sublistView(values, 0, count),
+      cache: const CacheManagerFactoryImpl().create(vectorCacheKeys),
+    );
+  }
+
+  Float32VectorSparse _multiplySparse(Float32VectorSparse other) {
+    final indices = <int>[];
+    final values = <double>[];
+    var i = 0;
+    var j = 0;
+
+    while (i < nnz && j < other.nnz) {
+      final leftIndex = _indices[i];
+      final rightIndex = other._indices[j];
+
+      if (leftIndex == rightIndex) {
+        final product = _values[i] * other._values[j];
+
+        if (product != 0.0) {
+          indices.add(leftIndex);
+          values.add(product);
+        }
+
+        i++;
+        j++;
+      } else if (leftIndex < rightIndex) {
+        i++;
+      } else {
+        j++;
+      }
+    }
+
+    return Float32VectorSparse._raw(
+      length: length,
+      indices: Int32List.fromList(indices),
+      values: Float32List.fromList(values),
+      cache: const CacheManagerFactoryImpl().create(vectorCacheKeys),
+    );
+  }
+
+  int _indexOf(int index) {
+    var low = 0;
+    var high = nnz - 1;
+
+    while (low <= high) {
+      final mid = (low + high) >> 1;
+      final midIndex = _indices[mid];
+
+      if (midIndex == index) {
+        return mid;
+      }
+
+      if (midIndex < index) {
+        low = mid + 1;
+      } else {
+        high = mid - 1;
+      }
+    }
+
+    return -1;
+  }
+
+  int _powerByNormType(Norm normType) {
+    switch (normType) {
+      case Norm.euclidean:
+        return 2;
+
+      case Norm.manhattan:
+        return 1;
+
+      default:
+        throw UnsupportedNormType(normType);
+    }
+  }
+
+  double _hammingDistance(Vector other) {
+    var distance = 0.0;
+
+    for (var i = 0; i < length; i++) {
+      if (this[i] != other[i]) {
+        distance++;
+      }
+    }
+
+    return distance;
+  }
+}
+
+class _Float32VectorSparseIterator implements Iterator<double> {
+  _Float32VectorSparseIterator(this._indices, this._values, this._length);
+
+  final Int32List _indices;
+  final Float32List _values;
+  final int _length;
+
+  int _position = -1;
+  int _sparsePosition = 0;
+  double _current = 0.0;
+
+  @override
+  double get current => _current;
+
+  @override
+  bool moveNext() {
+    _position++;
+
+    if (_position >= _length) {
+      return false;
+    }
+
+    if (_sparsePosition < _indices.length &&
+        _indices[_sparsePosition] == _position) {
+      _current = _values[_sparsePosition];
+      _sparsePosition++;
+    } else {
+      _current = 0.0;
+    }
+
+    return true;
+  }
+}

--- a/lib/src/vector/float32_vector_sparse.dart
+++ b/lib/src/vector/float32_vector_sparse.dart
@@ -221,9 +221,15 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
   }
 
   @override
-  Vector sqrt({bool skipCaching = false}) =>
-      _cache.get(vectorSqrtKey, () => _asDense().sqrt(skipCaching: true),
-          skipCaching: skipCaching);
+  Vector sqrt({bool skipCaching = false}) => _cache.get(vectorSqrtKey, () {
+        // Prefer the sparse path while clearly sparse; otherwise dense SIMD
+        // sqrt can be competitive.
+        if (nnz * 2 < length) {
+          return _mapValues(math.sqrt);
+        }
+
+        return _asDense().sqrt(skipCaching: true);
+      }, skipCaching: skipCaching);
 
   @override
   Vector scalarDiv(num scalar) => this / scalar;

--- a/lib/src/vector/float32_vector_sparse.dart
+++ b/lib/src/vector/float32_vector_sparse.dart
@@ -149,15 +149,16 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
           return 0;
         }
 
-        // Value-based hash of the full algebraic vector (including implicit
-        // zeros), so equal vectors share the same hashCode.
+        // O(nnz) hash over length and stored (index, value) pairs. Equal sparse
+        // vectors have the same non-zero layout, so they share hashCode.
         var hash = length;
 
-        for (final value in this) {
-          hash = 31 * hash + value.hashCode;
+        for (var i = 0; i < nnz; i++) {
+          hash = _mixHash(hash, _indices[i]);
+          hash = _mixHash(hash, _values[i].hashCode);
         }
 
-        return hash;
+        return _finalizeHash(hash);
       }, skipCaching: false);
 
   @override
@@ -701,6 +702,18 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
     }
 
     return distance;
+  }
+
+  static int _mixHash(int hash, int value) {
+    hash = 0x1fffffff & (hash + value);
+    hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
+    return hash ^ (hash >> 6);
+  }
+
+  static int _finalizeHash(int hash) {
+    hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
+    hash ^= hash >> 11;
+    return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
   }
 }
 

--- a/lib/src/vector/float32_vector_sparse.dart
+++ b/lib/src/vector/float32_vector_sparse.dart
@@ -21,20 +21,18 @@ import 'package:ml_linalg/src/vector/serialization/vector_to_json.dart';
 import 'package:ml_linalg/src/vector/vector_cache_keys.dart';
 import 'package:ml_linalg/vector.dart';
 
-/// A float32 sparse vector that stores only values different from [fill].
+/// A float32 sparse vector that stores only non-zero values.
 ///
-/// Missing indices are treated as [fill] (defaults to `0.0`).
+/// Missing indices are treated as `0.0`.
 class Float32VectorSparse with IterableMixin<double> implements Vector {
   /// Creates a sparse vector from [source], where keys are indices and values
   /// are vector elements.
   ///
-  /// Values equal to [fill] are ignored. Indices must be in `[0, length)`.
+  /// Zero values in [source] are ignored. Indices must be in `[0, length)`.
   Float32VectorSparse.fromMap(
     Map<int, num> source, {
     required this.length,
-    double fill = 0.0,
-  })  : _fill = fill,
-        _cache = const CacheManagerFactoryImpl().create(vectorCacheKeys) {
+  }) : _cache = const CacheManagerFactoryImpl().create(vectorCacheKeys) {
     if (length < 0) {
       throw ArgumentError.value(length, 'length', 'Cannot be negative');
     }
@@ -48,7 +46,7 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
 
       final doubleValue = value.toDouble();
 
-      if (doubleValue != _fill) {
+      if (doubleValue != 0.0) {
         entries.add(MapEntry(index, doubleValue));
       }
     });
@@ -69,38 +67,30 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
     required Int32List indices,
     required Float32List values,
     required CacheManager cache,
-    double fill = 0.0,
   })  : _indices = indices,
         _values = values,
-        _cache = cache,
-        _fill = fill;
+        _cache = cache;
 
   @override
   final int length;
 
   final CacheManager _cache;
-  final double _fill;
 
   late final Int32List _indices;
   late final Float32List _values;
 
-  /// Value used for indices that are not stored explicitly.
-  double get fill => _fill;
-
-  /// Number of explicitly stored elements that differ from [fill].
+  /// Number of non-zeros — how many explicitly stored (non-zero) elements.
   int get nnz => _indices.length;
 
   /// Whether the sparse path is preferred over densifying for element-wise ops.
   bool get _isClearlySparse => nnz * 2 < length;
-
-  bool get _hasZeroFill => _fill == 0.0;
 
   @override
   DType get dtype => DType.float32;
 
   @override
   Iterator<double> get iterator =>
-      _Float32VectorSparseIterator(_indices, _values, length, _fill);
+      _Float32VectorSparseIterator(_indices, _values, length);
 
   @override
   double operator [](int index) {
@@ -114,7 +104,7 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
 
     final position = _indexOf(index);
 
-    return position < 0 ? _fill : _values[position];
+    return position < 0 ? 0.0 : _values[position];
   }
 
   @override
@@ -127,8 +117,8 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
       return false;
     }
 
-    // Same sparse shape and fill ⇒ same algebraic vector.
-    if (other is Float32VectorSparse && _fill == other._fill) {
+    // Same sparse shape ⇒ same algebraic vector.
+    if (other is Float32VectorSparse) {
       if (nnz != other.nnz) {
         return false;
       }
@@ -148,7 +138,7 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
     for (var i = 0; i < length; i++) {
       final value = sparsePosition < nnz && _indices[sparsePosition] == i
           ? _values[sparsePosition++]
-          : _fill;
+          : 0.0;
 
       if (other[i] != value) {
         return false;
@@ -164,10 +154,9 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
           return 0;
         }
 
-        // O(nnz) hash over length, fill and stored (index, value) pairs.
+        // O(nnz) hash over length and stored (index, value) pairs. Equal sparse
+        // vectors have the same non-zero layout, so they share hashCode.
         var hash = length;
-
-        hash = mixHash(hash, _fill.hashCode);
 
         for (var i = 0; i < nnz; i++) {
           hash = mixHash(hash, _indices[i]);
@@ -193,18 +182,9 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
       return _asDense() * value;
     }
 
-    // Non-zero fill makes structural sparse multiply incorrect / densifying.
-    if (!_hasZeroFill) {
-      return _asDense() * value;
-    }
-
     if (value is Float32VectorSparse) {
       if (value.length != length) {
         throw VectorsLengthMismatchException(length, value.length);
-      }
-
-      if (!_hasZeroFill || !value._hasZeroFill) {
-        return _asDense() * value;
       }
 
       if (_isClearlySparse) {
@@ -283,7 +263,7 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
       return Vector.filled(length, 1.0, dtype: dtype);
     }
 
-    // Negative exponents turn fill/zeros into infinities, so densify.
+    // Negative exponents turn implicit zeros into infinities, so densify.
     if (exponent < 0) {
       return _asDense().pow(exponent);
     }
@@ -298,15 +278,9 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
   }
 
   @override
-  Vector exp({bool skipCaching = false}) => _cache.get(vectorExpKey, () {
-        // exp(fill) becomes the new fill (exp(0) = 1), so the result stays
-        // sparse without materializing the dense vector.
-        if (_isClearlySparse) {
-          return _mapValues(math.exp);
-        }
-
-        return _asDense().exp(skipCaching: true);
-      }, skipCaching: skipCaching);
+  Vector exp({bool skipCaching = false}) =>
+      _cache.get(vectorExpKey, () => _asDense().exp(skipCaching: true),
+          skipCaching: skipCaching);
 
   @override
   Vector log({bool skipCaching = false}) =>
@@ -330,22 +304,10 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
       throw VectorsLengthMismatchException(length, vector.length);
     }
 
-    if (_hasZeroFill) {
-      var result = 0.0;
-
-      for (var i = 0; i < nnz; i++) {
-        result += _values[i] * vector[_indices[i]];
-      }
-
-      return result;
-    }
-
-    // this[i] = fill + delta[i], so
-    // dot = fill * sum(other) + sum((value - fill) * other[index]).
-    var result = _fill * vector.sum(skipCaching: true);
+    var result = 0.0;
 
     for (var i = 0; i < nnz; i++) {
-      result += (_values[i] - _fill) * vector[_indices[i]];
+      result += _values[i] * vector[_indices[i]];
     }
 
     return result;
@@ -433,11 +395,6 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
           sumOfPowers += math.pow(_values[i].abs(), power).toDouble();
         }
 
-        if (nnz < length) {
-          sumOfPowers +=
-              (length - nnz) * math.pow(_fill.abs(), power).toDouble();
-        }
-
         return math.pow(sumOfPowers, 1 / power).toDouble();
       }, skipCaching: skipCaching);
 
@@ -448,7 +405,7 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
     }
 
     return _cache.get(vectorSumKey, () {
-      var result = _fill * (length - nnz);
+      var result = 0.0;
 
       for (var i = 0; i < nnz; i++) {
         result += _values[i];
@@ -464,7 +421,7 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
       return double.nan;
     }
 
-    if (_hasZeroFill && nnz < length) {
+    if (nnz < length) {
       return 0.0;
     }
 
@@ -472,10 +429,6 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
 
     for (var i = 0; i < nnz; i++) {
       result *= _values[i];
-    }
-
-    if (nnz < length) {
-      result *= math.pow(_fill, length - nnz).toDouble();
     }
 
     return result;
@@ -488,7 +441,7 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
         }
 
         if (nnz == 0) {
-          return _fill;
+          return 0.0;
         }
 
         var result = _values[0];
@@ -498,7 +451,7 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
         }
 
         if (nnz < length) {
-          result = math.max(result, _fill);
+          result = math.max(result, 0.0);
         }
 
         return result;
@@ -511,7 +464,7 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
         }
 
         if (nnz == 0) {
-          return _fill;
+          return 0.0;
         }
 
         var result = _values[0];
@@ -521,7 +474,7 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
         }
 
         if (nnz < length) {
-          result = math.min(result, _fill);
+          result = math.min(result, 0.0);
         }
 
         return result;
@@ -577,13 +530,13 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
       for (var i = 0; i < nnz; i++) _indices[i]: _values[i],
     };
 
-    if (value == _fill) {
+    if (value == 0) {
       map.remove(index);
     } else {
       map[index] = value;
     }
 
-    return Float32VectorSparse.fromMap(map, length: length, fill: _fill);
+    return Float32VectorSparse.fromMap(map, length: length);
   }
 
   @override
@@ -645,8 +598,7 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
       }
     }
 
-    return Float32VectorSparse.fromMap(map,
-        length: limit - start, fill: _fill);
+    return Float32VectorSparse.fromMap(map, length: limit - start);
   }
 
   @override
@@ -657,10 +609,6 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
   Float32List _toFloat32List() {
     final result = Float32List(length);
 
-    if (_fill != 0.0) {
-      result.fillRange(0, length, _fill);
-    }
-
     for (var i = 0; i < nnz; i++) {
       result[_indices[i]] = _values[i];
     }
@@ -669,7 +617,6 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
   }
 
   Float32VectorSparse _mapValues(double Function(double value) mapper) {
-    final newFill = mapper(_fill);
     final indices = Int32List(nnz);
     final values = Float32List(nnz);
     var count = 0;
@@ -677,7 +624,7 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
     for (var i = 0; i < nnz; i++) {
       final mapped = mapper(_values[i]);
 
-      if (mapped != newFill) {
+      if (mapped != 0.0) {
         indices[count] = _indices[i];
         values[count] = mapped;
         count++;
@@ -689,14 +636,11 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
       indices: Int32List.sublistView(indices, 0, count),
       values: Float32List.sublistView(values, 0, count),
       cache: const CacheManagerFactoryImpl().create(vectorCacheKeys),
-      fill: newFill,
     );
   }
 
   Float32VectorSparse _mapEntries(
       double Function(int index, double value) mapper) {
-    // Structural mapping of only stored entries is valid for zero-fill.
-    final newFill = _fill;
     final indices = Int32List(nnz);
     final values = Float32List(nnz);
     var count = 0;
@@ -704,7 +648,7 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
     for (var i = 0; i < nnz; i++) {
       final mapped = mapper(_indices[i], _values[i]);
 
-      if (mapped != newFill) {
+      if (mapped != 0.0) {
         indices[count] = _indices[i];
         values[count] = mapped;
         count++;
@@ -716,7 +660,6 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
       indices: Int32List.sublistView(indices, 0, count),
       values: Float32List.sublistView(values, 0, count),
       cache: const CacheManagerFactoryImpl().create(vectorCacheKeys),
-      fill: newFill,
     );
   }
 
@@ -804,17 +747,11 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
 }
 
 class _Float32VectorSparseIterator implements Iterator<double> {
-  _Float32VectorSparseIterator(
-    this._indices,
-    this._values,
-    this._length,
-    this._fill,
-  );
+  _Float32VectorSparseIterator(this._indices, this._values, this._length);
 
   final Int32List _indices;
   final Float32List _values;
   final int _length;
-  final double _fill;
 
   int _position = -1;
   int _sparsePosition = 0;
@@ -836,7 +773,7 @@ class _Float32VectorSparseIterator implements Iterator<double> {
       _current = _values[_sparsePosition];
       _sparsePosition++;
     } else {
-      _current = _fill;
+      _current = 0.0;
     }
 
     return true;

--- a/lib/src/vector/float32_vector_sparse.dart
+++ b/lib/src/vector/float32_vector_sparse.dart
@@ -82,6 +82,9 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
   /// Number of non-zeros — how many explicitly stored (non-zero) elements.
   int get nnz => _indices.length;
 
+  /// Whether the sparse path is preferred over densifying for element-wise ops.
+  bool get _isClearlySparse => nnz * 2 < length;
+
   @override
   DType get dtype => DType.float32;
 
@@ -224,7 +227,7 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
   Vector sqrt({bool skipCaching = false}) => _cache.get(vectorSqrtKey, () {
         // Prefer the sparse path while clearly sparse; otherwise dense SIMD
         // sqrt can be competitive.
-        if (nnz * 2 < length) {
+        if (_isClearlySparse) {
           return _mapValues(math.sqrt);
         }
 
@@ -262,7 +265,7 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
   Vector abs({bool skipCaching = false}) => _cache.get(vectorAbsKey, () {
         // Prefer the sparse path while clearly sparse; otherwise dense SIMD
         // abs can be competitive.
-        if (nnz * 2 < length) {
+        if (_isClearlySparse) {
           return _mapValues((value) => value.abs());
         }
 

--- a/lib/src/vector/float32_vector_sparse.dart
+++ b/lib/src/vector/float32_vector_sparse.dart
@@ -175,7 +175,11 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
   @override
   Vector operator *(Object value) {
     if (value is num) {
-      return _mapValues((element) => element * value.toDouble());
+      if (_isClearlySparse) {
+        return _mapValues((element) => element * value.toDouble());
+      }
+
+      return _asDense() * value;
     }
 
     if (value is Float32VectorSparse) {
@@ -183,7 +187,11 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
         throw VectorsLengthMismatchException(length, value.length);
       }
 
-      return _multiplySparse(value);
+      if (_isClearlySparse) {
+        return _multiplySparse(value);
+      }
+
+      return _asDense() * value;
     }
 
     if (value is Vector) {
@@ -191,7 +199,11 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
         throw VectorsLengthMismatchException(length, value.length);
       }
 
-      return _mapEntries((index, element) => element * value[index]);
+      if (_isClearlySparse) {
+        return _mapEntries((index, element) => element * value[index]);
+      }
+
+      return _asDense() * value;
     }
 
     if (value is Iterable<num>) {
@@ -200,7 +212,11 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
       }
 
       if (value is List<num>) {
-        return _mapEntries((index, element) => element * value[index]);
+        if (_isClearlySparse) {
+          return _mapEntries((index, element) => element * value[index]);
+        }
+
+        return _asDense() * value;
       }
 
       return _asDense() * value;
@@ -217,7 +233,11 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
   @override
   Vector operator /(Object value) {
     if (value is num) {
-      return _mapValues((element) => element / value.toDouble());
+      if (_isClearlySparse) {
+        return _mapValues((element) => element / value.toDouble());
+      }
+
+      return _asDense() / value;
     }
 
     return _asDense() / value;

--- a/lib/src/vector/float32_vector_sparse.dart
+++ b/lib/src/vector/float32_vector_sparse.dart
@@ -77,6 +77,7 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
   late final Int32List _indices;
   late final Float32List _values;
 
+  /// Number of non-zeros — how many explicitly stored (non-zero) elements.
   int get nnz => _indices.length;
 
   @override

--- a/lib/src/vector/float32_vector_sparse.dart
+++ b/lib/src/vector/float32_vector_sparse.dart
@@ -108,16 +108,34 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
       return true;
     }
 
-    if (other is! Float32VectorSparse) {
+    if (other is! Vector || length != other.length) {
       return false;
     }
 
-    if (length != other.length || nnz != other.nnz) {
-      return false;
+    // Same sparse shape ⇒ same algebraic vector.
+    if (other is Float32VectorSparse) {
+      if (nnz != other.nnz) {
+        return false;
+      }
+
+      for (var i = 0; i < nnz; i++) {
+        if (_indices[i] != other._indices[i] ||
+            _values[i] != other._values[i]) {
+          return false;
+        }
+      }
+
+      return true;
     }
 
-    for (var i = 0; i < nnz; i++) {
-      if (_indices[i] != other._indices[i] || _values[i] != other._values[i]) {
+    var sparsePosition = 0;
+
+    for (var i = 0; i < length; i++) {
+      final value = sparsePosition < nnz && _indices[sparsePosition] == i
+          ? _values[sparsePosition++]
+          : 0.0;
+
+      if (other[i] != value) {
         return false;
       }
     }
@@ -131,11 +149,12 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
           return 0;
         }
 
+        // Value-based hash of the full algebraic vector (including implicit
+        // zeros), so equal vectors share the same hashCode.
         var hash = length;
 
-        for (var i = 0; i < nnz; i++) {
-          hash = 31 * hash + _indices[i];
-          hash = 31 * hash + _values[i].hashCode;
+        for (final value in this) {
+          hash = 31 * hash + value.hashCode;
         }
 
         return hash;

--- a/lib/src/vector/float32_vector_sparse.dart
+++ b/lib/src/vector/float32_vector_sparse.dart
@@ -175,11 +175,7 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
   @override
   Vector operator *(Object value) {
     if (value is num) {
-      if (_isClearlySparse) {
-        return _mapValues((element) => element * value.toDouble());
-      }
-
-      return _asDense() * value;
+      return _mapValues((element) => element * value.toDouble());
     }
 
     if (value is Float32VectorSparse) {
@@ -187,11 +183,7 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
         throw VectorsLengthMismatchException(length, value.length);
       }
 
-      if (_isClearlySparse) {
-        return _multiplySparse(value);
-      }
-
-      return _asDense() * value;
+      return _multiplySparse(value);
     }
 
     if (value is Vector) {
@@ -199,11 +191,7 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
         throw VectorsLengthMismatchException(length, value.length);
       }
 
-      if (_isClearlySparse) {
-        return _mapEntries((index, element) => element * value[index]);
-      }
-
-      return _asDense() * value;
+      return _mapEntries((index, element) => element * value[index]);
     }
 
     if (value is Iterable<num>) {
@@ -212,11 +200,7 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
       }
 
       if (value is List<num>) {
-        if (_isClearlySparse) {
-          return _mapEntries((index, element) => element * value[index]);
-        }
-
-        return _asDense() * value;
+        return _mapEntries((index, element) => element * value[index]);
       }
 
       return _asDense() * value;
@@ -233,11 +217,7 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
   @override
   Vector operator /(Object value) {
     if (value is num) {
-      if (_isClearlySparse) {
-        return _mapValues((element) => element / value.toDouble());
-      }
-
-      return _asDense() / value;
+      return _mapValues((element) => element / value.toDouble());
     }
 
     return _asDense() / value;

--- a/lib/src/vector/float32_vector_sparse.dart
+++ b/lib/src/vector/float32_vector_sparse.dart
@@ -9,6 +9,8 @@ import 'package:ml_linalg/norm.dart';
 import 'package:ml_linalg/src/common/cache_manager/cache_manager.dart';
 import 'package:ml_linalg/src/common/cache_manager/cache_manager_factory_impl.dart';
 import 'package:ml_linalg/src/common/exception/unsupported_operand_type_exception.dart';
+import 'package:ml_linalg/src/common/hash/finalize_hash.dart';
+import 'package:ml_linalg/src/common/hash/mix_hash.dart';
 import 'package:ml_linalg/src/vector/exception/cosine_of_zero_vector_exception.dart';
 import 'package:ml_linalg/src/vector/exception/empty_vector_exception.dart';
 import 'package:ml_linalg/src/vector/exception/unsupported_distance_type_exception.dart';
@@ -154,11 +156,11 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
         var hash = length;
 
         for (var i = 0; i < nnz; i++) {
-          hash = _mixHash(hash, _indices[i]);
-          hash = _mixHash(hash, _values[i].hashCode);
+          hash = mixHash(hash, _indices[i]);
+          hash = mixHash(hash, _values[i].hashCode);
         }
 
-        return _finalizeHash(hash);
+        return finalizeHash(hash);
       }, skipCaching: false);
 
   @override
@@ -702,18 +704,6 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
     }
 
     return distance;
-  }
-
-  static int _mixHash(int hash, int value) {
-    hash = 0x1fffffff & (hash + value);
-    hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
-    return hash ^ (hash >> 6);
-  }
-
-  static int _finalizeHash(int hash) {
-    hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
-    hash ^= hash >> 11;
-    return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
   }
 }
 

--- a/lib/src/vector/float32_vector_sparse.dart
+++ b/lib/src/vector/float32_vector_sparse.dart
@@ -21,18 +21,20 @@ import 'package:ml_linalg/src/vector/serialization/vector_to_json.dart';
 import 'package:ml_linalg/src/vector/vector_cache_keys.dart';
 import 'package:ml_linalg/vector.dart';
 
-/// A float32 sparse vector that stores only non-zero values.
+/// A float32 sparse vector that stores only values different from [fill].
 ///
-/// Missing indices are treated as `0.0`.
+/// Missing indices are treated as [fill] (defaults to `0.0`).
 class Float32VectorSparse with IterableMixin<double> implements Vector {
   /// Creates a sparse vector from [source], where keys are indices and values
   /// are vector elements.
   ///
-  /// Zero values in [source] are ignored. Indices must be in `[0, length)`.
+  /// Values equal to [fill] are ignored. Indices must be in `[0, length)`.
   Float32VectorSparse.fromMap(
     Map<int, num> source, {
     required this.length,
-  }) : _cache = const CacheManagerFactoryImpl().create(vectorCacheKeys) {
+    double fill = 0.0,
+  })  : _fill = fill,
+        _cache = const CacheManagerFactoryImpl().create(vectorCacheKeys) {
     if (length < 0) {
       throw ArgumentError.value(length, 'length', 'Cannot be negative');
     }
@@ -46,7 +48,7 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
 
       final doubleValue = value.toDouble();
 
-      if (doubleValue != 0.0) {
+      if (doubleValue != _fill) {
         entries.add(MapEntry(index, doubleValue));
       }
     });
@@ -67,30 +69,38 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
     required Int32List indices,
     required Float32List values,
     required CacheManager cache,
+    double fill = 0.0,
   })  : _indices = indices,
         _values = values,
-        _cache = cache;
+        _cache = cache,
+        _fill = fill;
 
   @override
   final int length;
 
   final CacheManager _cache;
+  final double _fill;
 
   late final Int32List _indices;
   late final Float32List _values;
 
-  /// Number of non-zeros — how many explicitly stored (non-zero) elements.
+  /// Value used for indices that are not stored explicitly.
+  double get fill => _fill;
+
+  /// Number of explicitly stored elements that differ from [fill].
   int get nnz => _indices.length;
 
   /// Whether the sparse path is preferred over densifying for element-wise ops.
   bool get _isClearlySparse => nnz * 2 < length;
+
+  bool get _hasZeroFill => _fill == 0.0;
 
   @override
   DType get dtype => DType.float32;
 
   @override
   Iterator<double> get iterator =>
-      _Float32VectorSparseIterator(_indices, _values, length);
+      _Float32VectorSparseIterator(_indices, _values, length, _fill);
 
   @override
   double operator [](int index) {
@@ -104,7 +114,7 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
 
     final position = _indexOf(index);
 
-    return position < 0 ? 0.0 : _values[position];
+    return position < 0 ? _fill : _values[position];
   }
 
   @override
@@ -117,8 +127,8 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
       return false;
     }
 
-    // Same sparse shape ⇒ same algebraic vector.
-    if (other is Float32VectorSparse) {
+    // Same sparse shape and fill ⇒ same algebraic vector.
+    if (other is Float32VectorSparse && _fill == other._fill) {
       if (nnz != other.nnz) {
         return false;
       }
@@ -138,7 +148,7 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
     for (var i = 0; i < length; i++) {
       final value = sparsePosition < nnz && _indices[sparsePosition] == i
           ? _values[sparsePosition++]
-          : 0.0;
+          : _fill;
 
       if (other[i] != value) {
         return false;
@@ -154,9 +164,10 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
           return 0;
         }
 
-        // O(nnz) hash over length and stored (index, value) pairs. Equal sparse
-        // vectors have the same non-zero layout, so they share hashCode.
+        // O(nnz) hash over length, fill and stored (index, value) pairs.
         var hash = length;
+
+        hash = mixHash(hash, _fill.hashCode);
 
         for (var i = 0; i < nnz; i++) {
           hash = mixHash(hash, _indices[i]);
@@ -182,9 +193,18 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
       return _asDense() * value;
     }
 
+    // Non-zero fill makes structural sparse multiply incorrect / densifying.
+    if (!_hasZeroFill) {
+      return _asDense() * value;
+    }
+
     if (value is Float32VectorSparse) {
       if (value.length != length) {
         throw VectorsLengthMismatchException(length, value.length);
+      }
+
+      if (!_hasZeroFill || !value._hasZeroFill) {
+        return _asDense() * value;
       }
 
       if (_isClearlySparse) {
@@ -263,7 +283,7 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
       return Vector.filled(length, 1.0, dtype: dtype);
     }
 
-    // Negative exponents turn implicit zeros into infinities, so densify.
+    // Negative exponents turn fill/zeros into infinities, so densify.
     if (exponent < 0) {
       return _asDense().pow(exponent);
     }
@@ -278,9 +298,15 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
   }
 
   @override
-  Vector exp({bool skipCaching = false}) =>
-      _cache.get(vectorExpKey, () => _asDense().exp(skipCaching: true),
-          skipCaching: skipCaching);
+  Vector exp({bool skipCaching = false}) => _cache.get(vectorExpKey, () {
+        // exp(fill) becomes the new fill (exp(0) = 1), so the result stays
+        // sparse without materializing the dense vector.
+        if (_isClearlySparse) {
+          return _mapValues(math.exp);
+        }
+
+        return _asDense().exp(skipCaching: true);
+      }, skipCaching: skipCaching);
 
   @override
   Vector log({bool skipCaching = false}) =>
@@ -304,10 +330,22 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
       throw VectorsLengthMismatchException(length, vector.length);
     }
 
-    var result = 0.0;
+    if (_hasZeroFill) {
+      var result = 0.0;
+
+      for (var i = 0; i < nnz; i++) {
+        result += _values[i] * vector[_indices[i]];
+      }
+
+      return result;
+    }
+
+    // this[i] = fill + delta[i], so
+    // dot = fill * sum(other) + sum((value - fill) * other[index]).
+    var result = _fill * vector.sum(skipCaching: true);
 
     for (var i = 0; i < nnz; i++) {
-      result += _values[i] * vector[_indices[i]];
+      result += (_values[i] - _fill) * vector[_indices[i]];
     }
 
     return result;
@@ -395,6 +433,11 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
           sumOfPowers += math.pow(_values[i].abs(), power).toDouble();
         }
 
+        if (nnz < length) {
+          sumOfPowers +=
+              (length - nnz) * math.pow(_fill.abs(), power).toDouble();
+        }
+
         return math.pow(sumOfPowers, 1 / power).toDouble();
       }, skipCaching: skipCaching);
 
@@ -405,7 +448,7 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
     }
 
     return _cache.get(vectorSumKey, () {
-      var result = 0.0;
+      var result = _fill * (length - nnz);
 
       for (var i = 0; i < nnz; i++) {
         result += _values[i];
@@ -421,7 +464,7 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
       return double.nan;
     }
 
-    if (nnz < length) {
+    if (_hasZeroFill && nnz < length) {
       return 0.0;
     }
 
@@ -429,6 +472,10 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
 
     for (var i = 0; i < nnz; i++) {
       result *= _values[i];
+    }
+
+    if (nnz < length) {
+      result *= math.pow(_fill, length - nnz).toDouble();
     }
 
     return result;
@@ -441,7 +488,7 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
         }
 
         if (nnz == 0) {
-          return 0.0;
+          return _fill;
         }
 
         var result = _values[0];
@@ -451,7 +498,7 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
         }
 
         if (nnz < length) {
-          result = math.max(result, 0.0);
+          result = math.max(result, _fill);
         }
 
         return result;
@@ -464,7 +511,7 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
         }
 
         if (nnz == 0) {
-          return 0.0;
+          return _fill;
         }
 
         var result = _values[0];
@@ -474,7 +521,7 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
         }
 
         if (nnz < length) {
-          result = math.min(result, 0.0);
+          result = math.min(result, _fill);
         }
 
         return result;
@@ -530,13 +577,13 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
       for (var i = 0; i < nnz; i++) _indices[i]: _values[i],
     };
 
-    if (value == 0) {
+    if (value == _fill) {
       map.remove(index);
     } else {
       map[index] = value;
     }
 
-    return Float32VectorSparse.fromMap(map, length: length);
+    return Float32VectorSparse.fromMap(map, length: length, fill: _fill);
   }
 
   @override
@@ -598,7 +645,8 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
       }
     }
 
-    return Float32VectorSparse.fromMap(map, length: limit - start);
+    return Float32VectorSparse.fromMap(map,
+        length: limit - start, fill: _fill);
   }
 
   @override
@@ -609,6 +657,10 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
   Float32List _toFloat32List() {
     final result = Float32List(length);
 
+    if (_fill != 0.0) {
+      result.fillRange(0, length, _fill);
+    }
+
     for (var i = 0; i < nnz; i++) {
       result[_indices[i]] = _values[i];
     }
@@ -617,6 +669,7 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
   }
 
   Float32VectorSparse _mapValues(double Function(double value) mapper) {
+    final newFill = mapper(_fill);
     final indices = Int32List(nnz);
     final values = Float32List(nnz);
     var count = 0;
@@ -624,7 +677,7 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
     for (var i = 0; i < nnz; i++) {
       final mapped = mapper(_values[i]);
 
-      if (mapped != 0.0) {
+      if (mapped != newFill) {
         indices[count] = _indices[i];
         values[count] = mapped;
         count++;
@@ -636,11 +689,14 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
       indices: Int32List.sublistView(indices, 0, count),
       values: Float32List.sublistView(values, 0, count),
       cache: const CacheManagerFactoryImpl().create(vectorCacheKeys),
+      fill: newFill,
     );
   }
 
   Float32VectorSparse _mapEntries(
       double Function(int index, double value) mapper) {
+    // Structural mapping of only stored entries is valid for zero-fill.
+    final newFill = _fill;
     final indices = Int32List(nnz);
     final values = Float32List(nnz);
     var count = 0;
@@ -648,7 +704,7 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
     for (var i = 0; i < nnz; i++) {
       final mapped = mapper(_indices[i], _values[i]);
 
-      if (mapped != 0.0) {
+      if (mapped != newFill) {
         indices[count] = _indices[i];
         values[count] = mapped;
         count++;
@@ -660,6 +716,7 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
       indices: Int32List.sublistView(indices, 0, count),
       values: Float32List.sublistView(values, 0, count),
       cache: const CacheManagerFactoryImpl().create(vectorCacheKeys),
+      fill: newFill,
     );
   }
 
@@ -747,11 +804,17 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
 }
 
 class _Float32VectorSparseIterator implements Iterator<double> {
-  _Float32VectorSparseIterator(this._indices, this._values, this._length);
+  _Float32VectorSparseIterator(
+    this._indices,
+    this._values,
+    this._length,
+    this._fill,
+  );
 
   final Int32List _indices;
   final Float32List _values;
   final int _length;
+  final double _fill;
 
   int _position = -1;
   int _sparsePosition = 0;
@@ -773,7 +836,7 @@ class _Float32VectorSparseIterator implements Iterator<double> {
       _current = _values[_sparsePosition];
       _sparsePosition++;
     } else {
-      _current = 0.0;
+      _current = _fill;
     }
 
     return true;

--- a/lib/src/vector/float32_vector_sparse.dart
+++ b/lib/src/vector/float32_vector_sparse.dart
@@ -259,11 +259,15 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
           skipCaching: skipCaching);
 
   @override
-  Vector abs({bool skipCaching = false}) => _cache.get(
-        vectorAbsKey,
-        () => _mapValues((value) => value.abs()),
-        skipCaching: skipCaching,
-      );
+  Vector abs({bool skipCaching = false}) => _cache.get(vectorAbsKey, () {
+        // Prefer the sparse path while clearly sparse; otherwise dense SIMD
+        // abs can be competitive.
+        if (nnz * 2 < length) {
+          return _mapValues((value) => value.abs());
+        }
+
+        return _asDense().abs(skipCaching: true);
+      }, skipCaching: skipCaching);
 
   @override
   double dot(Vector vector) {

--- a/lib/src/vector/float32_vector_sparse.dart
+++ b/lib/src/vector/float32_vector_sparse.dart
@@ -248,7 +248,13 @@ class Float32VectorSparse with IterableMixin<double> implements Vector {
       return _asDense().pow(exponent);
     }
 
-    return _mapValues((value) => math.pow(value, exponent).toDouble());
+    // Prefer the sparse path while clearly sparse; otherwise dense SIMD
+    // pow can be competitive.
+    if (_isClearlySparse) {
+      return _mapValues((value) => math.pow(value, exponent).toDouble());
+    }
+
+    return _asDense().pow(exponent);
   }
 
   @override

--- a/test/common/hash/finalize_hash_test.dart
+++ b/test/common/hash/finalize_hash_test.dart
@@ -1,0 +1,43 @@
+import 'package:ml_linalg/src/common/hash/finalize_hash.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('finalizeHash', () {
+    test('should be deterministic', () {
+      expect(finalizeHash(123), finalizeHash(123));
+    });
+
+    test('should stay within the 31-bit mask', () {
+      final hash = finalizeHash(0x1fffffff);
+
+      expect(hash, lessThanOrEqualTo(0x1fffffff));
+      expect(hash, greaterThanOrEqualTo(0));
+    });
+
+    test('should change when the input hash changes', () {
+      expect(finalizeHash(1), isNot(finalizeHash(2)));
+    });
+
+    test('should avalanche a one-bit input change across the result', () {
+      final left = finalizeHash(1);
+      final right = finalizeHash(2);
+      final xor = left ^ right;
+      var changedBits = 0;
+
+      for (var bit = 0; bit < 31; bit++) {
+        if ((xor & (1 << bit)) != 0) {
+          changedBits++;
+        }
+      }
+
+      expect(changedBits, greaterThan(1));
+    });
+
+    test('should map zero to a stable non-negative value', () {
+      final hash = finalizeHash(0);
+
+      expect(hash, greaterThanOrEqualTo(0));
+      expect(hash, lessThanOrEqualTo(0x1fffffff));
+    });
+  });
+}

--- a/test/common/hash/mix_hash_test.dart
+++ b/test/common/hash/mix_hash_test.dart
@@ -1,0 +1,40 @@
+import 'package:ml_linalg/src/common/hash/mix_hash.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('mixHash', () {
+    test('should be deterministic', () {
+      expect(mixHash(1, 2), mixHash(1, 2));
+    });
+
+    test('should stay within the 31-bit mask', () {
+      final hash = mixHash(0x1fffffff, 0x1fffffff);
+
+      expect(hash, lessThanOrEqualTo(0x1fffffff));
+      expect(hash, greaterThanOrEqualTo(0));
+    });
+
+    test('should change when the mixed value changes', () {
+      expect(mixHash(10, 1), isNot(mixHash(10, 2)));
+    });
+
+    test('should change when the seed hash changes', () {
+      expect(mixHash(1, 10), isNot(mixHash(2, 10)));
+    });
+
+    test('should avalanche a one-bit input change across the result', () {
+      final left = mixHash(0, 1);
+      final right = mixHash(0, 2);
+      final xor = left ^ right;
+      var changedBits = 0;
+
+      for (var bit = 0; bit < 31; bit++) {
+        if ((xor & (1 << bit)) != 0) {
+          changedBits++;
+        }
+      }
+
+      expect(changedBits, greaterThan(1));
+    });
+  });
+}

--- a/test/vector/constructors/from_map/float32_vector_sparse_from_map_test.dart
+++ b/test/vector/constructors/from_map/float32_vector_sparse_from_map_test.dart
@@ -107,6 +107,31 @@ void main() {
       expect(absVector.toList(), [1.0, 2.0, 3.0, 0.0]);
     });
 
+    test('should keep positive pow sparse when nnz is less than half of length',
+        () {
+      final sparse = Float32VectorSparse.fromMap(
+        {0: 2.0, 3: 3.0},
+        length: 5,
+      );
+
+      final powered = sparse.pow(2);
+
+      expect(powered, isA<Float32VectorSparse>());
+      expect(powered.toList(), [4.0, 0.0, 0.0, 9.0, 0.0]);
+    });
+
+    test('should densify positive pow when nnz is at least half of length', () {
+      final sparse = Float32VectorSparse.fromMap(
+        {0: 2.0, 1: 3.0, 2: 4.0},
+        length: 4,
+      );
+
+      final powered = sparse.pow(2);
+
+      expect(powered, isNot(isA<Float32VectorSparse>()));
+      expect(powered.toList(), [4.0, 9.0, 16.0, 0.0]);
+    });
+
     test('should compute sparse-friendly aggregates', () {
       final sparse = Float32VectorSparse.fromMap(
         {0: 2.0, 2: -3.0, 4: 5.0},

--- a/test/vector/constructors/from_map/float32_vector_sparse_from_map_test.dart
+++ b/test/vector/constructors/from_map/float32_vector_sparse_from_map_test.dart
@@ -132,6 +132,73 @@ void main() {
       expect(powered.toList(), [4.0, 9.0, 16.0, 0.0]);
     });
 
+    test('should densify scalar multiply when nnz is at least half of length',
+        () {
+      final sparse = Float32VectorSparse.fromMap(
+        {0: 1.0, 1: 2.0, 2: 3.0},
+        length: 4,
+      );
+
+      final scaled = sparse * 2;
+
+      expect(scaled, isNot(isA<Float32VectorSparse>()));
+      expect(scaled.toList(), [2.0, 4.0, 6.0, 0.0]);
+    });
+
+    test('should keep scalar divide sparse when nnz is less than half of length',
+        () {
+      final sparse = Float32VectorSparse.fromMap(
+        {0: 2.0, 3: 4.0},
+        length: 5,
+      );
+
+      final divided = sparse / 2;
+
+      expect(divided, isA<Float32VectorSparse>());
+      expect(divided.toList(), [1.0, 0.0, 0.0, 2.0, 0.0]);
+    });
+
+    test('should densify scalar divide when nnz is at least half of length', () {
+      final sparse = Float32VectorSparse.fromMap(
+        {0: 2.0, 1: 4.0, 2: 6.0},
+        length: 4,
+      );
+
+      final divided = sparse / 2;
+
+      expect(divided, isNot(isA<Float32VectorSparse>()));
+      expect(divided.toList(), [1.0, 2.0, 3.0, 0.0]);
+    });
+
+    test('should keep vector multiply sparse when nnz is less than half of length',
+        () {
+      final sparse = Float32VectorSparse.fromMap(
+        {0: 2.0, 3: 4.0},
+        length: 5,
+      );
+      final other = Vector.fromList([3.0, 1.0, 1.0, 5.0, 1.0],
+          dtype: DType.float32);
+
+      final product = sparse * other;
+
+      expect(product, isA<Float32VectorSparse>());
+      expect(product.toList(), [6.0, 0.0, 0.0, 20.0, 0.0]);
+    });
+
+    test('should densify vector multiply when nnz is at least half of length',
+        () {
+      final sparse = Float32VectorSparse.fromMap(
+        {0: 2.0, 1: 3.0, 2: 4.0},
+        length: 4,
+      );
+      final other = Vector.fromList([5.0, 6.0, 7.0, 8.0], dtype: DType.float32);
+
+      final product = sparse * other;
+
+      expect(product, isNot(isA<Float32VectorSparse>()));
+      expect(product.toList(), [10.0, 18.0, 28.0, 0.0]);
+    });
+
     test('should compute sparse-friendly aggregates', () {
       final sparse = Float32VectorSparse.fromMap(
         {0: 2.0, 2: -3.0, 4: 5.0},

--- a/test/vector/constructors/from_map/float32_vector_sparse_from_map_test.dart
+++ b/test/vector/constructors/from_map/float32_vector_sparse_from_map_test.dart
@@ -71,6 +71,30 @@ void main() {
       expect(scaled.toList(), [0.0, -4.0, 0.0, 8.0, 0.0]);
     });
 
+    test('should keep sqrt sparse when nnz is less than half of length', () {
+      final sparse = Float32VectorSparse.fromMap(
+        {0: 4.0, 3: 9.0},
+        length: 5,
+      );
+
+      final rooted = sparse.sqrt();
+
+      expect(rooted, isA<Float32VectorSparse>());
+      expect(rooted.toList(), [2.0, 0.0, 0.0, 3.0, 0.0]);
+    });
+
+    test('should densify sqrt when nnz is at least half of length', () {
+      final sparse = Float32VectorSparse.fromMap(
+        {0: 4.0, 1: 9.0, 2: 16.0},
+        length: 4,
+      );
+
+      final rooted = sparse.sqrt();
+
+      expect(rooted, isNot(isA<Float32VectorSparse>()));
+      expect(rooted.toList(), [2.0, 3.0, 4.0, 0.0]);
+    });
+
     test('should compute sparse-friendly aggregates', () {
       final sparse = Float32VectorSparse.fromMap(
         {0: 2.0, 2: -3.0, 4: 5.0},

--- a/test/vector/constructors/from_map/float32_vector_sparse_from_map_test.dart
+++ b/test/vector/constructors/from_map/float32_vector_sparse_from_map_test.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:ml_linalg/distance.dart';
 import 'package:ml_linalg/dtype.dart';
 import 'package:ml_linalg/norm.dart';
@@ -197,6 +199,39 @@ void main() {
 
       expect(product, isNot(isA<Float32VectorSparse>()));
       expect(product.toList(), [10.0, 18.0, 28.0, 0.0]);
+    });
+
+    test('should keep exp sparse with fill equal to e^0', () {
+      final sparse = Float32VectorSparse.fromMap(
+        {2: math.log(2.0)},
+        length: 4,
+      );
+
+      final exponentiated = sparse.exp() as Float32VectorSparse;
+
+      expect(exponentiated, isA<Float32VectorSparse>());
+      expect(exponentiated.fill, 1.0);
+      expect(exponentiated.nnz, 1);
+      expect(exponentiated[0], 1.0);
+      expect(exponentiated[1], 1.0);
+      expect(exponentiated[2], closeTo(2.0, 1e-5));
+      expect(exponentiated[3], 1.0);
+      expect(exponentiated.sum(), closeTo(5.0, 1e-5));
+    });
+
+    test('should densify exp when nnz is at least half of length', () {
+      final sparse = Float32VectorSparse.fromMap(
+        {0: math.log(2.0), 1: math.log(3.0), 2: math.log(4.0)},
+        length: 4,
+      );
+
+      final exponentiated = sparse.exp();
+
+      expect(exponentiated, isNot(isA<Float32VectorSparse>()));
+      expect(exponentiated[0], closeTo(2.0, 1e-5));
+      expect(exponentiated[1], closeTo(3.0, 1e-5));
+      expect(exponentiated[2], closeTo(4.0, 1e-5));
+      expect(exponentiated[3], closeTo(1.0, 1e-5));
     });
 
     test('should compute sparse-friendly aggregates', () {

--- a/test/vector/constructors/from_map/float32_vector_sparse_from_map_test.dart
+++ b/test/vector/constructors/from_map/float32_vector_sparse_from_map_test.dart
@@ -132,8 +132,7 @@ void main() {
       expect(powered.toList(), [4.0, 9.0, 16.0, 0.0]);
     });
 
-    test('should densify scalar multiply when nnz is at least half of length',
-        () {
+    test('should keep scalar multiply sparse even when nnz is high', () {
       final sparse = Float32VectorSparse.fromMap(
         {0: 1.0, 1: 2.0, 2: 3.0},
         length: 4,
@@ -141,24 +140,11 @@ void main() {
 
       final scaled = sparse * 2;
 
-      expect(scaled, isNot(isA<Float32VectorSparse>()));
+      expect(scaled, isA<Float32VectorSparse>());
       expect(scaled.toList(), [2.0, 4.0, 6.0, 0.0]);
     });
 
-    test('should keep scalar divide sparse when nnz is less than half of length',
-        () {
-      final sparse = Float32VectorSparse.fromMap(
-        {0: 2.0, 3: 4.0},
-        length: 5,
-      );
-
-      final divided = sparse / 2;
-
-      expect(divided, isA<Float32VectorSparse>());
-      expect(divided.toList(), [1.0, 0.0, 0.0, 2.0, 0.0]);
-    });
-
-    test('should densify scalar divide when nnz is at least half of length', () {
+    test('should keep scalar divide sparse even when nnz is high', () {
       final sparse = Float32VectorSparse.fromMap(
         {0: 2.0, 1: 4.0, 2: 6.0},
         length: 4,
@@ -166,27 +152,11 @@ void main() {
 
       final divided = sparse / 2;
 
-      expect(divided, isNot(isA<Float32VectorSparse>()));
+      expect(divided, isA<Float32VectorSparse>());
       expect(divided.toList(), [1.0, 2.0, 3.0, 0.0]);
     });
 
-    test('should keep vector multiply sparse when nnz is less than half of length',
-        () {
-      final sparse = Float32VectorSparse.fromMap(
-        {0: 2.0, 3: 4.0},
-        length: 5,
-      );
-      final other = Vector.fromList([3.0, 1.0, 1.0, 5.0, 1.0],
-          dtype: DType.float32);
-
-      final product = sparse * other;
-
-      expect(product, isA<Float32VectorSparse>());
-      expect(product.toList(), [6.0, 0.0, 0.0, 20.0, 0.0]);
-    });
-
-    test('should densify vector multiply when nnz is at least half of length',
-        () {
+    test('should keep vector multiply sparse even when nnz is high', () {
       final sparse = Float32VectorSparse.fromMap(
         {0: 2.0, 1: 3.0, 2: 4.0},
         length: 4,
@@ -195,7 +165,7 @@ void main() {
 
       final product = sparse * other;
 
-      expect(product, isNot(isA<Float32VectorSparse>()));
+      expect(product, isA<Float32VectorSparse>());
       expect(product.toList(), [10.0, 18.0, 28.0, 0.0]);
     });
 

--- a/test/vector/constructors/from_map/float32_vector_sparse_from_map_test.dart
+++ b/test/vector/constructors/from_map/float32_vector_sparse_from_map_test.dart
@@ -93,6 +93,24 @@ void main() {
       );
     });
 
+    test('should compare algebraically with another Vector by values', () {
+      final sparse = Float32VectorSparse.fromMap(
+        {0: 1.0, 2: 3.0},
+        length: 3,
+      );
+      final sameSparse = Float32VectorSparse.fromMap(
+        {2: 3.0, 0: 1.0},
+        length: 3,
+      );
+      final dense = Vector.fromList([1.0, 0.0, 3.0], dtype: DType.float32);
+      final different = Vector.fromList([1.0, 0.0, 4.0], dtype: DType.float32);
+
+      expect(sparse == sameSparse, isTrue);
+      expect(sparse == dense, isTrue);
+      expect(sparse == different, isFalse);
+      expect(sparse.hashCode, sameSparse.hashCode);
+    });
+
     test('should update values through set and keep sparse representation', () {
       final sparse = Float32VectorSparse.fromMap(
         {0: 1.0, 2: 3.0},

--- a/test/vector/constructors/from_map/float32_vector_sparse_from_map_test.dart
+++ b/test/vector/constructors/from_map/float32_vector_sparse_from_map_test.dart
@@ -95,6 +95,18 @@ void main() {
       expect(rooted.toList(), [2.0, 3.0, 4.0, 0.0]);
     });
 
+    test('should densify abs when nnz is at least half of length', () {
+      final sparse = Float32VectorSparse.fromMap(
+        {0: -1.0, 1: 2.0, 2: -3.0},
+        length: 4,
+      );
+
+      final absVector = sparse.abs();
+
+      expect(absVector, isNot(isA<Float32VectorSparse>()));
+      expect(absVector.toList(), [1.0, 2.0, 3.0, 0.0]);
+    });
+
     test('should compute sparse-friendly aggregates', () {
       final sparse = Float32VectorSparse.fromMap(
         {0: 2.0, 2: -3.0, 4: 5.0},

--- a/test/vector/constructors/from_map/float32_vector_sparse_from_map_test.dart
+++ b/test/vector/constructors/from_map/float32_vector_sparse_from_map_test.dart
@@ -1,0 +1,108 @@
+import 'package:ml_linalg/distance.dart';
+import 'package:ml_linalg/dtype.dart';
+import 'package:ml_linalg/norm.dart';
+import 'package:ml_linalg/src/vector/float32_vector_sparse.dart';
+import 'package:ml_linalg/vector.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Float32VectorSparse.fromMap', () {
+    test('should create a sparse vector with implicit zeros', () {
+      final vector = Float32VectorSparse.fromMap(
+        {0: 1.0, 3: 2.5, 5: -1.0},
+        length: 6,
+      );
+
+      expect(vector, isA<Vector>());
+      expect(vector.dtype, DType.float32);
+      expect(vector.length, 6);
+      expect(vector.nnz, 3);
+      expect(vector.toList(), [1.0, 0.0, 0.0, 2.5, 0.0, -1.0]);
+    });
+
+    test('should ignore explicit zeros in the source map', () {
+      final vector = Float32VectorSparse.fromMap(
+        {1: 0.0, 2: 4.0, 4: 0.0},
+        length: 5,
+      );
+
+      expect(vector.nnz, 1);
+      expect(vector.toList(), [0.0, 0.0, 4.0, 0.0, 0.0]);
+    });
+
+    test('should throw if length is negative', () {
+      expect(
+        () => Float32VectorSparse.fromMap({}, length: -1),
+        throwsArgumentError,
+      );
+    });
+
+    test('should throw if an index is out of range', () {
+      expect(
+        () => Float32VectorSparse.fromMap({5: 1.0}, length: 5),
+        throwsRangeError,
+      );
+    });
+
+    test('should support Vector arithmetic through dense fallback', () {
+      final sparse = Float32VectorSparse.fromMap(
+        {0: 1.0, 2: 3.0},
+        length: 3,
+      );
+      final dense = Vector.fromList([1.0, 2.0, 3.0], dtype: DType.float32);
+
+      expect((sparse + dense).toList(), [2.0, 2.0, 6.0]);
+      expect((sparse - 1).toList(), [0.0, -1.0, 2.0]);
+    });
+
+    test('should keep sparsity for value-only maps and scalar multiplication',
+        () {
+      final sparse = Float32VectorSparse.fromMap(
+        {1: -2.0, 3: 4.0},
+        length: 5,
+      );
+
+      final absVector = sparse.abs();
+      final scaled = sparse * 2;
+
+      expect(absVector, isA<Float32VectorSparse>());
+      expect(scaled, isA<Float32VectorSparse>());
+      expect(absVector.toList(), [0.0, 2.0, 0.0, 4.0, 0.0]);
+      expect(scaled.toList(), [0.0, -4.0, 0.0, 8.0, 0.0]);
+    });
+
+    test('should compute sparse-friendly aggregates', () {
+      final sparse = Float32VectorSparse.fromMap(
+        {0: 2.0, 2: -3.0, 4: 5.0},
+        length: 5,
+      );
+
+      expect(sparse.sum(), 4.0);
+      expect(sparse.prod(), 0.0);
+      expect(sparse.min(), -3.0);
+      expect(sparse.max(), 5.0);
+      expect(sparse.mean(), closeTo(0.8, 1e-6));
+      expect(sparse.dot(Vector.fromList([1, 1, 1, 1, 1])), 4.0);
+      expect(sparse.norm(Norm.manhattan), 10.0);
+      expect(
+        sparse.distanceTo(
+          Vector.fromList([2, 0, -3, 0, 5]),
+          distance: Distance.euclidean,
+        ),
+        0.0,
+      );
+    });
+
+    test('should update values through set and keep sparse representation', () {
+      final sparse = Float32VectorSparse.fromMap(
+        {0: 1.0, 2: 3.0},
+        length: 4,
+      );
+
+      final updated = sparse.set(2, 0).set(1, 7) as Float32VectorSparse;
+
+      expect(updated.nnz, 2);
+      expect(updated.toList(), [1.0, 7.0, 0.0, 0.0]);
+    });
+  });
+}

--- a/test/vector/constructors/from_map/float32_vector_sparse_from_map_test.dart
+++ b/test/vector/constructors/from_map/float32_vector_sparse_from_map_test.dart
@@ -1,5 +1,3 @@
-import 'dart:math' as math;
-
 import 'package:ml_linalg/distance.dart';
 import 'package:ml_linalg/dtype.dart';
 import 'package:ml_linalg/norm.dart';
@@ -199,39 +197,6 @@ void main() {
 
       expect(product, isNot(isA<Float32VectorSparse>()));
       expect(product.toList(), [10.0, 18.0, 28.0, 0.0]);
-    });
-
-    test('should keep exp sparse with fill equal to e^0', () {
-      final sparse = Float32VectorSparse.fromMap(
-        {2: math.log(2.0)},
-        length: 4,
-      );
-
-      final exponentiated = sparse.exp() as Float32VectorSparse;
-
-      expect(exponentiated, isA<Float32VectorSparse>());
-      expect(exponentiated.fill, 1.0);
-      expect(exponentiated.nnz, 1);
-      expect(exponentiated[0], 1.0);
-      expect(exponentiated[1], 1.0);
-      expect(exponentiated[2], closeTo(2.0, 1e-5));
-      expect(exponentiated[3], 1.0);
-      expect(exponentiated.sum(), closeTo(5.0, 1e-5));
-    });
-
-    test('should densify exp when nnz is at least half of length', () {
-      final sparse = Float32VectorSparse.fromMap(
-        {0: math.log(2.0), 1: math.log(3.0), 2: math.log(4.0)},
-        length: 4,
-      );
-
-      final exponentiated = sparse.exp();
-
-      expect(exponentiated, isNot(isA<Float32VectorSparse>()));
-      expect(exponentiated[0], closeTo(2.0, 1e-5));
-      expect(exponentiated[1], closeTo(3.0, 1e-5));
-      expect(exponentiated[2], closeTo(4.0, 1e-5));
-      expect(exponentiated[3], closeTo(1.0, 1e-5));
     });
 
     test('should compute sparse-friendly aggregates', () {

--- a/test/vector/integration/float32_vector_sparse_integration_test.dart
+++ b/test/vector/integration/float32_vector_sparse_integration_test.dart
@@ -1,0 +1,124 @@
+import 'package:ml_linalg/distance.dart';
+import 'package:ml_linalg/dtype.dart';
+import 'package:ml_linalg/norm.dart';
+import 'package:ml_linalg/src/vector/float32_vector_sparse.dart';
+import 'package:ml_linalg/vector.dart';
+import 'package:test/test.dart';
+
+/// Integration-style smoke test for sparse vectors without mocks.
+///
+/// Models a tiny on-device text scenario: bag-of-words vectors over a large
+/// vocabulary, TF scaling, cosine ranking and feature intersection.
+void main() {
+  group('Float32VectorSparse integration', () {
+    // Vocabulary-sized feature space with only a handful of present terms.
+    const vocabSize = 50000;
+
+    // termId -> raw count
+    const queryTerms = <int, num>{
+      12: 1,
+      450: 2,
+      8900: 1,
+      12000: 3,
+      48001: 1,
+    };
+
+    const documentTerms = <int, num>{
+      12: 2,
+      450: 1,
+      3300: 4,
+      12000: 1,
+      22000: 2,
+      48001: 1,
+    };
+
+    late Float32VectorSparse query;
+    late Float32VectorSparse document;
+
+    setUp(() {
+      query = Float32VectorSparse.fromMap(queryTerms, length: vocabSize);
+      document =
+          Float32VectorSparse.fromMap(documentTerms, length: vocabSize);
+    });
+
+    test('keeps bag-of-words vectors compressed over a large vocabulary', () {
+      expect(query.length, vocabSize);
+      expect(document.length, vocabSize);
+      expect(query.nnz, queryTerms.length);
+      expect(document.nnz, documentTerms.length);
+
+      // Absent terms are real zeros, not stored entries.
+      expect(query[0], 0.0);
+      expect(query[12], 1.0);
+      expect(query[12000], 3.0);
+      expect(document[3300], 4.0);
+      expect(document[9999], 0.0);
+    });
+
+    test('ranks a document against a query with sparse cosine similarity', () {
+      // Simple TF scaling: emphasize repeated terms.
+      final scaledQuery = query * 1.0;
+      final scaledDocument = document * 1.0;
+
+      expect(scaledQuery, isA<Float32VectorSparse>());
+      expect(scaledDocument, isA<Float32VectorSparse>());
+      expect((scaledQuery as Float32VectorSparse).nnz, query.nnz);
+      expect((scaledDocument as Float32VectorSparse).nnz, document.nnz);
+
+      final score = scaledQuery.distanceTo(
+        scaledDocument,
+        distance: Distance.cosine,
+      );
+
+      // Cosine distance in [0, 2]; overlapping BoW vectors should be similar.
+      expect(score, greaterThanOrEqualTo(0.0));
+      expect(score, lessThan(1.0));
+
+      final denseQuery =
+          Vector.fromList(query.toList(), dtype: DType.float32);
+      final denseDocument =
+          Vector.fromList(document.toList(), dtype: DType.float32);
+      final denseScore = denseQuery.distanceTo(
+        denseDocument,
+        distance: Distance.cosine,
+      );
+
+      expect(score, closeTo(denseScore, 1e-5));
+    });
+
+    test('intersects features with sparse element-wise multiply', () {
+      final overlap = query * document;
+
+      expect(overlap, isA<Float32VectorSparse>());
+      expect((overlap as Float32VectorSparse).nnz, 4);
+      expect(overlap[12], 2.0); // 1 * 2
+      expect(overlap[450], 2.0); // 2 * 1
+      expect(overlap[12000], 3.0); // 3 * 1
+      expect(overlap[48001], 1.0); // 1 * 1
+      expect(overlap[3300], 0.0); // present only in document
+      expect(overlap[8900], 0.0); // present only in query
+
+      // Shared-term mass via sparse-friendly reductions.
+      expect(overlap.sum(), 8.0);
+      expect(overlap.dot(Vector.filled(vocabSize, 1.0)), 8.0);
+      expect(overlap.norm(Norm.manhattan), 8.0);
+    });
+
+    test('updates a live sparse representation through set', () {
+      final updated = query.set(12, 0).set(42, 5) as Float32VectorSparse;
+
+      expect(updated.nnz, query.nnz); // removed one, added one
+      expect(updated[12], 0.0);
+      expect(updated[42], 5.0);
+      expect(updated[12000], 3.0);
+
+      final refreshedScore = updated.distanceTo(
+        document,
+        distance: Distance.cosine,
+      );
+
+      expect(refreshedScore.isFinite, isTrue);
+      expect(refreshedScore, greaterThanOrEqualTo(0.0));
+    });
+  });
+}

--- a/test/vector/integration/float32_vector_sparse_integration_test.dart
+++ b/test/vector/integration/float32_vector_sparse_integration_test.dart
@@ -8,7 +8,7 @@ import 'package:test/test.dart';
 /// Integration-style smoke test for sparse vectors without mocks.
 ///
 /// Models a tiny on-device text scenario: bag-of-words vectors over a large
-/// vocabulary, TF scaling, cosine ranking and feature intersection.
+/// vocabulary, cosine ranking and feature intersection.
 void main() {
   group('Float32VectorSparse integration', () {
     // Vocabulary-sized feature space with only a handful of present terms.
@@ -58,17 +58,8 @@ void main() {
 
     test('should rank a document against a query with sparse cosine similarity',
         () {
-      // Simple TF scaling: emphasize repeated terms.
-      final scaledQuery = query * 1.0;
-      final scaledDocument = document * 1.0;
-
-      expect(scaledQuery, isA<Float32VectorSparse>());
-      expect(scaledDocument, isA<Float32VectorSparse>());
-      expect((scaledQuery as Float32VectorSparse).nnz, query.nnz);
-      expect((scaledDocument as Float32VectorSparse).nnz, document.nnz);
-
-      final score = scaledQuery.distanceTo(
-        scaledDocument,
+      final score = query.distanceTo(
+        document,
         distance: Distance.cosine,
       );
 

--- a/test/vector/integration/float32_vector_sparse_integration_test.dart
+++ b/test/vector/integration/float32_vector_sparse_integration_test.dart
@@ -41,7 +41,8 @@ void main() {
           Float32VectorSparse.fromMap(documentTerms, length: vocabSize);
     });
 
-    test('keeps bag-of-words vectors compressed over a large vocabulary', () {
+    test('should keep bag-of-words vectors compressed over a large vocabulary',
+        () {
       expect(query.length, vocabSize);
       expect(document.length, vocabSize);
       expect(query.nnz, queryTerms.length);
@@ -55,7 +56,8 @@ void main() {
       expect(document[9999], 0.0);
     });
 
-    test('ranks a document against a query with sparse cosine similarity', () {
+    test('should rank a document against a query with sparse cosine similarity',
+        () {
       // Simple TF scaling: emphasize repeated terms.
       final scaledQuery = query * 1.0;
       final scaledDocument = document * 1.0;
@@ -86,7 +88,7 @@ void main() {
       expect(score, closeTo(denseScore, 1e-5));
     });
 
-    test('intersects features with sparse element-wise multiply', () {
+    test('should intersect features with sparse element-wise multiply', () {
       final overlap = query * document;
 
       expect(overlap, isA<Float32VectorSparse>());
@@ -104,7 +106,7 @@ void main() {
       expect(overlap.norm(Norm.manhattan), 8.0);
     });
 
-    test('updates a live sparse representation through set', () {
+    test('should update a live sparse representation through set', () {
       final updated = query.set(12, 0).set(42, 5) as Float32VectorSparse;
 
       expect(updated.nnz, query.nnz); // removed one, added one


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds `Float32VectorSparse`, a float32 sparse vector implementation that satisfies the full `Vector` interface.

## Details
- Constructor: `Float32VectorSparse.fromMap(Map<int, num> source, {required int length})`
- Stores sorted non-zero index/value pairs; missing positions are `0.0`
- Algebraic `==` / `hashCode` by vector values (works across `Vector` implementations from the sparse side)
- Sparse-friendly paths for `[]`, `sum`, `dot`, `norm`, `min`/`max`, `abs`, scalar `*`/`/`, sparse `*`, `set`, `subvector`
- Remaining operations currently fall back to a dense `Vector` for correctness
- Basic unit tests for construction and core behavior

## Notes
Branch rebased onto rewritten `master`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-667c8955-9781-432a-a76f-03b919eef5ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-667c8955-9781-432a-a76f-03b919eef5ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

